### PR TITLE
Implement connection timeout

### DIFF
--- a/spec/redis/connection/celluloid_spec.rb
+++ b/spec/redis/connection/celluloid_spec.rb
@@ -21,4 +21,8 @@ describe Redis::Connection::Celluloid do
       expect { redis.shutdown }.not_to raise_error
     end
   end
+
+  it "times out when taking too long to connect" do
+    expect { Redis.new(:host => "10.255.255.254", :timeout => 0.1).ping }.to raise_error(Redis::CannotConnectError)
+  end
 end


### PR DESCRIPTION
Is there a downside to implementing the connection timeout using the Future timeout feature?

I originally started out with [your suggestion to implement a first-class Celluloid::Timeout](https://groups.google.com/d/msg/celluloid-ruby/wNPmox7eowI/OorElxzYHHIJ). But my first cut at that used this same Future-based strategy: [gist](https://gist.github.com/simonrobson/5393451)
